### PR TITLE
Add info for supported stock firmware versions and for flashing 3.1.5

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -22,7 +22,7 @@ Lastly, in difficult cases, the mod includes recovery and uninstall firmware ima
 > e.g. 1.3.x to 1.4.x
 
 ### Prerequisites
-
+- Stock firmware version minimum **2.6.5** and maximum **3.1.5**. Newer versions are currently not supported and may cause instability - follow the instructions [here](/docs/UNINSTALL.md#flashing-factory-firmware) to downgrade the firmware to a supported version if necessary before proceeding.
 - A USB flash drive formatted to FAT32.
 - At least 512MB free space in the `/data` partition.
 - At least 128MB free space in the `/` partition.
@@ -37,7 +37,6 @@ The mod uses the same installation mechanism as the stock firmware:
 5. The printer will automatically install the update. After the installation is finished, you will see a message at the end of the screen.  
 6. Eject the USB drive and reboot the printer.  
 
-**Note**: The mod installer currently requires the printer to be updated to at least version **2.6.5** of the stock Flashforge firmware.  
 After installation, the printer will boot into the modified firmware by default.
 
 From this point onward, you will receive OTA updates from this repository.

--- a/docs/UNINSTALL.md
+++ b/docs/UNINSTALL.md
@@ -53,7 +53,9 @@ It's **recommended** to flash the uninstall image first, to ensure there are no 
      - Pro: [Adventurer5MPro-2.7.8-2.2.3-20241213-Factory.tgz](https://github.com/DrA1ex/ff5m/releases/download/1.2.0/Adventurer5MPro-2.7.8-2.2.3-20241213-Factory.tgz)   
    - **3.1.3 Factory images**
      - Non-Pro: [Adventurer5M-3.1.3-2.2.3-20250107-Factory.tgz](https://github.com/DrA1ex/ff5m/releases/download/1.2.0/Adventurer5M-3.1.3-2.2.3-20250107-Factory.tgz)   
-     - Pro: [Adventurer5MPro-3.1.3-2.2.3-20250107-Factory.tgz](https://github.com/DrA1ex/ff5m/releases/download/1.2.0/Adventurer5MPro-3.1.3-2.2.3-20250107-Factory.tgz)   
+     - Pro: [Adventurer5MPro-3.1.3-2.2.3-20250107-Factory.tgz](https://github.com/DrA1ex/ff5m/releases/download/1.2.0/Adventurer5MPro-3.1.3-2.2.3-20250107-Factory.tgz)
+> [!NOTE]
+> The official 3.1.5 firmware available on the Flashforge website does not include printer config files. To install 3.1.5 while restoring those files it's necessary to first flash the above 3.1.3 firmware and then flash the 3.1.5 firmware.
 2. (Optional) Before flashing, check the integrity of the firmware file using the MD5 checksum:  
    - **Version 2.7.8**:  
      - Non-Pro: `608cb3830e69d1ff946bf699d69c491f`  


### PR DESCRIPTION
I saw advice about this on the discord but did not realize the reason until going through the process myself. Is the provided tgz for 3.1.3 a manual dump from a stock machine or otherwise manually put together? It's surprising to me that FF decided to omit the configs from the official files as afaik there's no way to restore it otherwise (not that they have a great track record on the software side).

Let me know if you'd like any wording to be changed or other places in the docs to be updated.