### PR TITLE
Cap glibc malloc arenas on Moonraker and GuppyScreen

### DIFF
--- a/.root/S65moonraker
+++ b/.root/S65moonraker
@@ -13,7 +13,13 @@ start() {
     echo "Starting Moonraker..."
     rm -rf $PRINTER_DATA_TMP && mkdir -p $PRINTER_DATA_TMP # clean temp
     export TMPDIR=$PRINTER_DATA_TMP # without TMPDIR moonraker writes to /tmp which is a ramdisk
-    
+
+    # Cap glibc per-thread malloc arenas. Moonraker's threadpool otherwise lets
+    # glibc create up to 8*nCPU arenas (16 on the dual-core T113), each growing
+    # its own heap independently and inflating RSS. Capping to 2 reclaims a few
+    # MB of RSS on the 128 MB box with no functional change.
+    export MALLOC_ARENA_MAX=2
+
     start-stop-daemon -S -b -m -p $PID_FILE --exec $PYTHON -- $MOONRAKER -d $PRINTER_DATA
     [ $? = 0 ] && echo "OK" || echo "FAIL"
 }

--- a/.root/S80guppyscreen
+++ b/.root/S80guppyscreen
@@ -10,6 +10,10 @@ NICENESS=10
 
 start() {
 	echo "Starting guppyscreen..."
+	# GuppyScreen is multi-threaded (LVGL loop + Moonraker WebSocket client), so
+	# cap glibc malloc arenas like Moonraker. Reclaims RSS on the 128 MB box with
+	# no functional change.
+	export MALLOC_ARENA_MAX=2
 	start-stop-daemon -S -b -m -p $PID_FILE -N $NICENESS --exec /bin/sh -- -c $GUPPYSCREEN
 	[ $? = 0 ] && echo "OK" || echo "FAIL"
 }


### PR DESCRIPTION
## What

Set `MALLOC_ARENA_MAX=2` for the two long-running, multi-threaded daemons the mod
starts: **Moonraker** (`S65moonraker`) and **GuppyScreen** (`S80guppyscreen`).

## Why

glibc creates a separate malloc arena per thread, up to `8 * nCPU` (16 on the
dual-core T113). Each arena grows its own heap independently, so a threaded
process ends up holding far more RSS than it actually uses. Moonraker runs a
thread pool and GuppyScreen runs an LVGL loop plus a Moonraker WebSocket client
thread, so both are affected. On the 128 MB AD5M this matters.

Capping to 2 keeps a little allocator parallelism while bounding the per-thread
arena bloat.

## Measured

qemu (cortex-a7, `-smp 2`, idle): capping Moonraker's arenas cuts its RSS by
~2.7 MB versus the glibc default. This is a floor — under load, as the thread
pool activates, more uncapped arenas would be created, so the real-world saving
is larger. GuppyScreen benefits from the same mechanism.

No functional change.