### PR TITLE
Suppress stock slicer-upgrade nag on the stock screen

### DIFF
--- a/.shell/boot/boot.sh
+++ b/.shell/boot/boot.sh
@@ -22,6 +22,23 @@ fi
 DISPLAY_OFF=0
 [ "$("$CMDS"/zdisplay.sh test)" != "STOCK" ] && DISPLAY_OFF=1
 
+# The stock QT app (firmwareExe) pops a "Please upgrade the slicer software to
+# version V1.7.3 or later." modal on every boot of the stock screen, even at
+# idle with nothing to print. MainWindow::checkAppTip() shows it whenever
+# Config::getCheckAppFrist() (the general/CheckAppFrist flag in Adventurer5M.json)
+# is true, so clearing the flag suppresses the nag for good. Only relevant when
+# the stock screen is in use - on Feather/Headless/Guppy firmwareExe never runs.
+suppress_slicer_nag() {
+    local config_file
+    config_file=$(ls /opt/config/Adventurer5M*.json 2>/dev/null | head -1)
+    [ -f "$config_file" ] || return 0
+
+    grep -q '"CheckAppFrist"[ ]*:[ ]*true' "$config_file" || return 0
+
+    echo "// Suppressing stock slicer-upgrade nag (CheckAppFrist=false)"
+    sed -i 's/\("CheckAppFrist"[ ]*:[ ]*\)true/\1false/' "$config_file"
+}
+
 wifi_init() {
     if [ -f "/etc/wpa_supplicant.conf" ]; then
         echo "Configuration found"
@@ -126,7 +143,9 @@ elif [ "$DISPLAY_OFF" -eq 1 ]; then
     /opt/config/mod/.shell/commands/zdisplay.sh stock --skip-reboot
 
     echo "@@ Failed to initialize mod. Booting into stock firmware..."
+    suppress_slicer_nag
     sleep 1
 else
     echo "// Booting stock firmware..."
+    suppress_slicer_nag
 fi


### PR DESCRIPTION
The stock FlashForge QT app (`firmwareExe`) pops a modal on every boot of the stock screen:

> Please upgrade the slicer software to version V1.7.3 or later.

with a single **Ok** button. It shows even when the printer is idle with nothing loaded, so it is pure noise that has to be dismissed on every power-up.

## Root cause

The string is shown by `MainWindow::checkAppTip()`. The first thing that function does is:

```
bl   Config::getCheckAppFrist()   ; read general/CheckAppFrist
cbnz r0, show_nag                 ; if non-zero -> build + show the modal
...                               ; else return immediately
```

`Config::getCheckAppFrist()` reads the `general/CheckAppFrist` boolean from `Adventurer5M.json`, and `checkAppTip()` is invoked from `MainWindow::checkRocoveryPrint()` at startup, which is why it fires on every boot regardless of print state. On a fresh stock config `CheckAppFrist` is `true`.

So the entire nag is gated by one config flag — no binary patching required.

## Fix

In `boot.sh`, when the stock screen is the active display (the only case where `firmwareExe` runs), set `general/CheckAppFrist` to `false` in `Adventurer5M*.json` before the stock UI starts. This reuses the existing `grep`/`sed`-on-`Adventurer5M*.json` style already in `boot.sh`. It is idempotent (only rewrites when the flag is still `true`) and leaves the neighbouring `CheckZFrist` flag untouched.

Feather / Headless / Guppy paths never launch `firmwareExe`, so they are unaffected.

## Test plan

- Offline, in a rootless qemu render of the stock UI:
  - Baseline (`CheckAppFrist=true`): the home screen renders with the "Please upgrade the slicer software to version V1.7.3 or later." modal on top.
  - With `CheckAppFrist=false`: same boot, same conditions, the slicer modal is gone.
- `bash -n .shell/boot/boot.sh` passes; the `sed` was verified against the real tab-indented `"CheckAppFrist" : true` field and flips only that key.
- Not yet verified on physical hardware — review welcome on the chosen hook point in `boot.sh`.