### PR TITLE
Fix SHAPER_CALIBRATE deadlock when the result exceeds the pipe buffer

### DIFF
--- a/.py/klipper/patches/extras/shaper_calibrate.py
+++ b/.py/klipper/patches/extras/shaper_calibrate.py
@@ -93,6 +93,12 @@ class ShaperCalibrate:
         gcode = self.printer.lookup_object("gcode")
         eventtime = last_report_time = reactor.monotonic()
         while calc_proc.is_alive():
+            # Break as soon as the child has buffered its result: a large result
+            # blocks the child's send() on a full pipe (~64 KB), so the child
+            # never exits and is_alive() stays true forever -- deadlock. poll()
+            # lets us recv() and drain the pipe so the child can finish.
+            if parent_conn.poll():
+                break
             if eventtime > last_report_time + 5.:
                 last_report_time = eventtime
                 gcode.respond_info("Wait for calculations..", log=False)


### PR DESCRIPTION
## Symptom

`ZSHAPER` / `SHAPER_CALIBRATE` hangs forever after `// Wait for calculations..` — klippy's gcode thread is wedged, CPU idle, no result, no error. Reproduces on the AD5M (128 MB).

## Cause

`ShaperCalibrate.background_process_exec()` (`.py/klipper/patches/extras/shaper_calibrate.py`) runs the calc in a child process and does:

```python
while calc_proc.is_alive():
    ... reactor.pause ...
is_err, res = parent_conn.recv()   # only after the loop
```

The child ends with `child_conn.send((False, res))`. When `res` is larger than the OS pipe buffer (~64 KB on Linux — the resonance result is), `send()` **blocks** until the parent reads. But the parent only reads after the loop, and the loop only ends when the child dies — which it can't, because it's blocked in `send()`. Classic pipe deadlock; both sides idle.

## Fix

Poll the connection inside the wait loop and break as soon as the result is buffered, so `recv()` drains the pipe and lets the child finish:

```python
if parent_conn.poll():
    break
```

One added check; no behaviour change for small results (the child finishes and `is_alive()` goes false as before).