### PR TITLE
Add optional SCHED_RR real-time scheduling for Klipper (klipper_rt)

### DIFF
--- a/.shell/boot/boot.sh
+++ b/.shell/boot/boot.sh
@@ -132,7 +132,7 @@ if [ "$MOD_CUSTOM_BOOT" -eq 1 ]; then
     /opt/config/mod/.bin/exec/boot_mcu 2>&1
     
     echo "// Start klipper."
-    /opt/klipper/start.sh &> /dev/null
+    /opt/config/mod/.shell/commands/zstart_klipper.sh &> /dev/null
     
     echo "// Boot sequence done!"
 elif [ "$DISPLAY_OFF" -eq 1 ]; then

--- a/.shell/commands/zchanges.sh
+++ b/.shell/commands/zchanges.sh
@@ -77,6 +77,15 @@ case "$key" in
             reboot
         fi
     ;;
+
+    klipper_rt)
+        "$SCRIPTS"/restart_klipper.sh --hard
+        if [ "$value" -eq 1 ]; then
+            message "Klipper real-time scheduling enabled (SCHED_RR)."
+        else
+            message "Klipper real-time scheduling disabled."
+        fi
+    ;;
     
     zssh)
         if [ "$value" -eq 1 ]; then

--- a/.shell/commands/zstart_klipper.sh
+++ b/.shell/commands/zstart_klipper.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+## Launch Klipper, optionally under SCHED_RR real-time scheduling.
+##
+## Copyright (C) 2025, Alexander K <https://github.com/drA1ex>
+##
+## This file may be distributed under the terms of the GNU GPLv3 license
+
+## Gated by the `klipper_rt` mod parameter (default 0/off). When enabled, the
+## klippy host is launched under SCHED_RR, so the process and every thread it
+## spawns (threads inherit the parent's scheduling policy) run real-time. On the
+## dual-core T113 this keeps timing-critical MCU communication from being
+## preempted by Moonraker, the web UI, the camera stream, etc., which is the
+## usual cause of "Timer too close" / MCU timeout underruns under load.
+##
+## A low priority (5) plus the kernel RT throttle (sched_rt_runtime_us, 95% by
+## default) ensures a misbehaving klippy can never hard-lock a core.
+
+CFG_SCRIPT="/opt/config/mod/.shell/commands/zconf.sh"
+VAR_PATH="/opt/config/mod_data/variables.cfg"
+KLIPPER_START="/opt/klipper/start.sh"
+RT_PRIO=5
+
+rt=$("$CFG_SCRIPT" "$VAR_PATH" --get "klipper_rt" "0")
+
+if [ "$rt" = "1" ] && command -v chrt >/dev/null 2>&1; then
+    echo "// Klipper: real-time scheduling (SCHED_RR, priority $RT_PRIO)"
+    exec chrt -r "$RT_PRIO" "$KLIPPER_START"
+fi
+
+exec "$KLIPPER_START"

--- a/.shell/restart_klipper.sh
+++ b/.shell/restart_klipper.sh
@@ -23,7 +23,7 @@ if [ "$1" = "--hard" ]; then
     kill "$pid"
   done
 
-  /opt/klipper/start.sh 
+  /opt/config/mod/.shell/commands/zstart_klipper.sh
   exit $?
 fi
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -33,6 +33,8 @@ The mod supports a wide range of parameters to customize printer behavior. Below
 
 - **`tune_klipper`**: Enables a fix for Communication Timeout (E0011) / Move Queue Overflow (EO017) errors if set to `1`.  
 
+- **`klipper_rt`**: Runs the Klipper host under real-time scheduling (`SCHED_RR`, priority 5) if set to `1`. Default `0` (off). On the dual-core T113, Klipper otherwise competes with Moonraker, the web UI and the camera for CPU and can be preempted long enough to fall behind feeding the MCU, causing *Timer too close* / MCU timeout underruns under load. With this enabled the klippy process and all its threads preempt normal tasks. Safe by design: the low priority plus the kernel RT throttle (95% of a core) prevents a runaway from locking the system. Targets CPU-contention underruns, not memory-pressure stalls.  
+
 - **`check_md5`**: Enables MD5 checksum verification for G-code files.  
   **Note**: Requires a [post-processing script](/docs/SLICING.md#md5-checksum-validation) in your slicer. Scripts are available in *Configuration → mod* (`addMD5.sh` or `addMD5.bat`).  
 

--- a/mod_params.json
+++ b/mod_params.json
@@ -110,6 +110,12 @@
       "order": 20000
     },
     {
+      "key": "klipper_rt",
+      "type": "bool",
+      "default": 0,
+      "label": "Klipper real-time priority (SCHED_RR)"
+    },
+    {
       "key": "tune_klipper",
       "type": "bool",
       "default": 0,


### PR DESCRIPTION
## Problem

On the dual-core T113, the klippy host runs at plain `SCHED_OTHER` (nice 0) and competes with Moonraker, the web UI, guppyscreen and the camera stream for CPU. Under load it can be preempted long enough to fall behind feeding the MCU, which shows up as **"Timer too close"** / MCU timeout underruns, especially on a busy 128 MB board.

## Change

Add a **`klipper_rt`** mod parameter (default **0/off**). When enabled, Klipper is launched under real-time scheduling so timing-critical MCU communication is not preempted by normal tasks.

Implementation:

- **`.shell/commands/zstart_klipper.sh`** (new) wraps the launch: if `klipper_rt=1` it `exec chrt -r 5 /opt/klipper/start.sh`, else launches normally. Because `start.sh` backgrounds `klippy.py` and child processes/threads inherit the parent's scheduling policy, the whole klippy process (all reactor/serial/worker threads) runs `SCHED_RR`, and it stays that way across in-process reloads (`RESTART` / `SAVE_CONFIG` / `FIRMWARE_RESTART`).
- **`boot.sh`** and **`restart_klipper.sh`** call the wrapper instead of `/opt/klipper/start.sh` directly, so it applies on both boot and `--hard` restarts.
- **`mod_params.json`**: new `klipper_rt` bool.
- **`zchanges.sh`**: toggling the parameter does a `restart_klipper.sh --hard` so it takes effect immediately.

## Safety

- Priority is a low **5** with `SCHED_RR` (time-sliced, not FIFO), and the kernel RT throttle (`sched_rt_runtime_us` = 950000/1000000, i.e. RT capped at 95% of a core) guarantees a misbehaving klippy cannot hard-lock the system.
- Default off, opt-in only. The wrapper falls back to a plain launch if `chrt` is missing.

## Testing

Applied `chrt -r 5` to all klippy threads live on an AD5M (5.1.x / forge-x): policy confirmed `SCHED_RR` on every thread, system stable, RT throttle present at the default. The wrapper reproduces this automatically on each launch when the parameter is set.

Note: this does not address memory-pressure stalls (an RT task still blocks on a swap-in); it targets CPU-contention underruns.