### PR TITLE
Fix Moonraker reboot/shutdown on non-systemd systems

### DIFF
--- a/.root/moonraker/components/machine.py
+++ b/.root/moonraker/components/machine.py
@@ -1615,6 +1615,12 @@ class SimpleProvider(BaseProvider):
         self.script_path = config.get("script_path", "/etc/init.d/")
         self.script_timeout = config.getfloat("script_timeout", 30.)
 
+    async def shutdown(self) -> None:
+        await self._exec_sudo_command(self.shutdown_action)
+
+    async def reboot(self) -> None:
+        await self._exec_sudo_command("reboot")
+
     async def do_service_action(
         self, action: str, service_name: str
     ) -> None:


### PR DESCRIPTION
## Problem

Moonraker's `/machine/reboot` and `/machine/shutdown` endpoints fail on Forge-X.

`SimpleProvider` is the provider selected when the host has no systemd (it drives services by exec'ing scripts out of `/etc/init.d/`). But it does not override `shutdown()` / `reboot()`, so it inherits `BaseProvider`'s implementations:

```python
async def shutdown(self) -> None:
    await self._exec_sudo_command(f"systemctl {self.shutdown_action}")

async def reboot(self) -> None:
    await self._exec_sudo_command("systemctl reboot")
```

There is no `systemctl` on the AD5M, so both calls fail. Fluidd, Mainsail, and screen UIs can't power the printer off or restart it from the web/UI.

## Fix

Override both in `SimpleProvider` to invoke the commands directly:

```python
async def shutdown(self) -> None:
    await self._exec_sudo_command(self.shutdown_action)

async def reboot(self) -> None:
    await self._exec_sudo_command("reboot")
```

`shutdown_action` is already validated in `BaseProvider.__init__` to be either `halt` or `poweroff`, so passing it through as the command is safe and keeps the existing `[machine] shutdown_action` config option working.

Six lines, no behavior change for systemd hosts (they use a different provider).
