### PR TITLE
Scale the parameter suggestion threshold to name length

### DIFF
--- a/.py/klipper/plugins/mod_params.py
+++ b/.py/klipper/plugins/mod_params.py
@@ -363,17 +363,18 @@ class ModParamManagement:
         # Compute distances from misspelled name to each parameter
         distances = [(param, ModParamManagement._levenshtein_distance(misspelled, param)) for param in param_list]
 
-        # Find the minimum distance
-        min_distance = min(distances, key=lambda x: x[1])[1]
+        # Find the closest parameter (first one wins if several tie)
+        closest_param, min_distance = min(distances, key=lambda x: x[1])
 
-        if min_distance <= 10:
-            closest_params = [param for param, dist in distances if dist == min_distance]
+        # Scale the tolerance to the parameter's length. A fixed allowance wide
+        # enough for "bed_mesh_validation_tolerance" also matches anything at
+        # all against a short name like "zssh", which turns every unknown
+        # parameter into a confident wrong guess.
+        if min_distance <= max(2, len(closest_param) // 3):
+            return closest_param
 
-            # Return the first one (arbitrary choice if multiple matches)
-            return closest_params[0]
-        else:
-            # If the smallest distance is too large, return None
-            return None
+        # Nothing close enough to be worth suggesting.
+        return None
 
 
 def load_config(config):


### PR DESCRIPTION
## Problem

`SET_MOD PARAM=zzzzzzzz VALUE=1` replies:

```
!! Unknown parameter: 'zzzzzzzz'
Did you mean this?
SET_MOD PARAM='display' VALUE='1'
```

`_find_similar_param` accepts any Levenshtein distance up to 10. That is wider than most parameter names are long, so nearly any input matches something. The distance from `zzzzzzzz` to `display` is 8.

The bad hint is the visible symptom, but the behavioural consequence is worse. In `cmd_SET_MOD_PARAM`, finding a suggestion takes the `return` path instead of the `raise gcmd.error(...)` path below it:

```python
similar_key = self._find_similar_param(key, list(self.params_map.keys()))
if similar_key:
    gcmd.respond_raw(f"!! Unknown parameter: {key!r}")
    ...
    return
else:
    raise gcmd.error(f'Unknown parameter: "{key}"')
```

So a misspelled `SET_MOD` inside a macro **succeeds silently and does nothing**, rather than failing the way an unknown command should. The `else` branch is reachable only for input much longer than any parameter name.

## Fix

Scale the allowance to the length of the candidate:

```python
if min_distance <= max(2, len(closest_param) // 3):
```

A short name like `zssh` tolerates 2 edits; a long one like `bed_mesh_validation_tolerance` tolerates 9. The `max(2, ...)` floor keeps ordinary single-character typos working on short names.

The diff also collapses the `min()` call and the list rebuild into one lookup, since `min()` already returns the first minimum and the old code recomputed the same thing.

## Verification

Against all 41 parameters in `mod_params.json`:

- **163 of 164** generated single-edit typo variants (truncation, dropped character, case slip, transposition) still resolve to their source key. The one exception is `midi_en`, which is distance 1 from both `midi_end` and `midi_on` — a genuine tie, not a threshold effect, and it behaves the same before and after.
- **Zero** of 14 random strings produce a suggestion, where previously all of them did.

Spot checks:

| Input | Before | After |
|---|---|---|
| `backlite` | `backlight` | `backlight` |
| `dispaly` | `display` | `display` |
| `camra` | `camera` | `camera` |
| `z_ofset` | `z_offset` | `z_offset` |
| `zzzzzzzz` | `display` | no suggestion, raises |
| `qqqq` | `zssh` | no suggestion, raises |
| `""` | `zssh` | no suggestion, raises |

## Note

`max(2, len // 3)` is a judgement call rather than the only right answer. If you would prefer a different shape (a fixed small constant, or a similarity ratio), the surrounding change stands on its own and I am happy to adjust.
