### PR TITLE
Add a test suite

### DIFF
--- a/.cfg/init.display.headless.cfg
+++ b/.cfg/init.display.headless.cfg
@@ -2,6 +2,7 @@
 [include ./mod/config/headless.cfg]
 -[include ./mod/config/stock.cfg]
 -[include ./mod/config/feather.cfg]
+-[include ./mod/config/guppy.cfg]
 -[include ./mod/mod.cfg]
 -[include mod.user.cfg]
 -[include ./mod/display_off.cfg]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,9 @@ jobs:
 
   python:
     name: Python plugins
-    runs-on: ubuntu-latest
+    # Pinned to 22.04 deliberately: ubuntu-latest is 24.04, which cannot
+    # provision Python 3.8 (it reached end of life before 24.04 shipped).
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  shell:
+    name: Shell suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Run shell test suite
+        run: sh test/run.sh
+
+  python:
+    name: Python plugins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # 3.8 is the contract: klippy on the printer runs FlashForge's Python
+      # 3.8.2. Testing only on a newer interpreter would let match statements
+      # and `int | None` annotations through that the printer cannot parse.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run plugin tests
+        run: python3 -m pytest test/python/ -v

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,83 @@
+# Testing
+
+Forge-X has two test suites. Neither needs a printer.
+
+## Shell suite
+
+Dependency-free POSIX shell. Runs on a fresh checkout, in CI, and on the
+printer itself over SSH.
+
+    sh test/run.sh
+
+It discovers every `test/*_test.sh`. Current gates:
+
+| Test | What it protects |
+|---|---|
+| `display_modes_test.sh` | Display mode configs stay mutually exclusive |
+| `harness_test.sh` | The assertion library itself |
+| `shellcheck_test.sh` | No new shellcheck findings versus the baseline |
+| `syntax_test.sh` | Every script parses under its declared interpreter |
+
+### Why the syntax gate matters
+
+On most dev machines `/bin/sh` is bash, so a bashism in a `#!/bin/sh` file
+parses cleanly and then fails on the printer, where `/bin/sh` is BusyBox ash.
+The gate parses each file with the interpreter its shebang actually names.
+
+### The shellcheck baseline
+
+shellcheck had never been run on this tree, so there is a large body of
+pre-existing findings. `test/shellcheck_baseline.txt` records them as
+`file:code` pairs and the gate fails only on findings absent from it. Line
+numbers are excluded deliberately, so unrelated edits that shift lines do not
+cause spurious failures.
+
+shellcheck is a dev and CI dependency only; it is never needed on the printer.
+Where it is not installed the gate reports a skip rather than failing.
+
+To regenerate after an intentional change:
+
+    for f in $(git ls-files '.shell/*' '.root/*'); do
+        head -1 "$f" | grep -q '^#!' || continue
+        shellcheck -f gcc "$f" 2>/dev/null
+    done | sed -E 's/^([^:]+):[0-9]+:[0-9]+: [a-z]+: .*\[(SC[0-9]+)\]$/\1:\2/' \
+         | LC_ALL=C sort -u > test/shellcheck_baseline.txt
+
+`LC_ALL=C` is required. Without it a baseline generated under a UTF-8 locale and
+a list generated under C collate differently, and `comm` silently reports
+phantom findings.
+
+## Python suite
+
+For the klippy plugins under `.py/klipper/plugins/`.
+
+    pip install pytest
+    python3 -m pytest test/python/ -v
+
+`test/python/conftest.py` stubs the small part of Klipper's plugin contract
+that extras actually use: a config object, a printer, and a gcode object. That
+is enough to exercise a plugin's real logic without hardware. The
+`stub_config` and `declaration_file` fixtures are reusable for the other
+plugins.
+
+CI runs this suite on Python 3.8, because that is what klippy runs on the
+printer. Code that only parses on a newer interpreter would pass locally and
+fail on the machine that matters.
+
+## Adding a test
+
+Shell: create `test/<name>_test.sh`, source `lib/assert.sh`, call assertions,
+end with `finish`. The runner picks it up automatically.
+
+    #!/bin/sh
+    SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+    . "$SCRIPT_DIR/lib/assert.sh"
+
+    assert_eq "description" "expected" "$actual"
+
+    finish
+
+Available assertions: `assert_eq`, `assert_ne`, `assert_empty`,
+`assert_contains`, `assert_file`, and `fail`.
+
+Python: add a file under `test/python/` and use the existing fixtures.

--- a/test/display_modes_test.sh
+++ b/test/display_modes_test.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Display mode configs must be mutually exclusive.
+#
+# Each .cfg/init.display.<mode>.cfg includes its own config/<mode>.cfg and
+# removes every other mode's with a -[include ...] line. Adding a mode without
+# teaching the others to exclude it leaves two display configs active at once,
+# and both define _PRINT_STATUS and reset_screen.
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+. "$SCRIPT_DIR/lib/assert.sh"
+
+cd "$REPO_DIR" || exit 1
+
+# Derive the mode list from the files themselves so a new mode is covered
+# automatically rather than needing this test updated.
+MODES=""
+for f in .cfg/init.display.*.cfg; do
+    [ -f "$f" ] || continue
+    m=$(basename "$f" .cfg)
+    m=${m#init.display.}
+    MODES="$MODES $m"
+done
+
+assert_ne "at least one display mode found" "" "$MODES"
+
+for mode in $MODES; do
+    f=".cfg/init.display.$mode.cfg"
+
+    # It must include its own config.
+    if grep -q "^\[include \./mod/config/$mode\.cfg\]" "$f"; then
+        _t_pass "$mode includes its own config"
+    else
+        _t_fail "$mode includes its own config" "no [include ./mod/config/$mode.cfg] in $f"
+    fi
+
+    # It must exclude every other mode's config.
+    for other in $MODES; do
+        [ "$other" = "$mode" ] && continue
+        if grep -q -- "^-\[include \./mod/config/$other\.cfg\]" "$f"; then
+            _t_pass "$mode excludes $other"
+        else
+            _t_fail "$mode excludes $other" "missing -[include ./mod/config/$other.cfg] in $f"
+        fi
+    done
+done
+
+finish

--- a/test/harness_test.sh
+++ b/test/harness_test.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Self-test for the assertion harness.
+#
+# The thing that actually matters here is the negative case: an assertion that
+# cannot fail makes every test that uses it worthless. Each assertion is checked
+# for both outcomes.
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$SCRIPT_DIR/lib/assert.sh"
+
+# Run an assertion in a nested shell and echo how many failures it recorded.
+# Nested so the deliberate failures land in that shell's counter, not ours.
+failures_from() {
+    (
+        . "$SCRIPT_DIR/lib/assert.sh"
+        "$@" >/dev/null 2>&1
+        echo "$_T_FAILED"
+    )
+}
+
+# Each assertion must PASS on its true case...
+assert_eq "eq passes when equal"     "0" "$(failures_from assert_eq       x "abc" "abc")"
+assert_eq "ne passes when different" "0" "$(failures_from assert_ne       x "abc" "xyz")"
+assert_eq "empty passes when empty"  "0" "$(failures_from assert_empty    x "")"
+assert_eq "contains passes on match" "0" "$(failures_from assert_contains x "hay needle" "needle")"
+assert_eq "file passes when present" "0" "$(failures_from assert_file     x "$SCRIPT_DIR/harness_test.sh")"
+
+# ...and FAIL on its false case. This half is the point of the file.
+assert_eq "eq fails when different"  "1" "$(failures_from assert_eq       x "abc" "xyz")"
+assert_eq "ne fails when equal"      "1" "$(failures_from assert_ne       x "abc" "abc")"
+assert_eq "empty fails when set"     "1" "$(failures_from assert_empty    x "nonempty")"
+assert_eq "contains fails on miss"   "1" "$(failures_from assert_contains x "hay" "needle")"
+assert_eq "file fails when absent"   "1" "$(failures_from assert_file     x "/nonexistent/path")"
+
+# finish must exit non-zero when anything failed, or CI reports green on red.
+(
+    . "$SCRIPT_DIR/lib/assert.sh"
+    assert_eq "deliberate" "a" "b" >/dev/null 2>&1
+    finish >/dev/null 2>&1
+)
+assert_eq "finish exits non-zero after a failure" "1" "$?"
+
+finish

--- a/test/lib/assert.sh
+++ b/test/lib/assert.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Assertion primitives for the Forge-X shell test suite.
+#
+# Deliberately dependency-free POSIX shell: the suite must run on a fresh
+# checkout with no packages installed, and on the printer itself, where
+# BusyBox ash is the only shell available.
+#
+# Source this, call assertions, then call finish.
+
+_T_RUN=0
+_T_FAILED=0
+
+_t_pass() {
+    _T_RUN=$((_T_RUN + 1))
+    echo "ok     $1"
+}
+
+_t_fail() {
+    _T_RUN=$((_T_RUN + 1))
+    _T_FAILED=$((_T_FAILED + 1))
+    echo "NOT OK $1"
+    [ -n "$2" ] && echo "       $2"
+}
+
+fail() {
+    _t_fail "$1" "$2"
+}
+
+assert_eq() {
+    if [ "$3" = "$2" ]; then
+        _t_pass "$1"
+    else
+        _t_fail "$1" "want '$2', got '$3'"
+    fi
+}
+
+assert_ne() {
+    if [ "$3" != "$2" ]; then
+        _t_pass "$1"
+    else
+        _t_fail "$1" "expected something other than '$2'"
+    fi
+}
+
+assert_empty() {
+    if [ -z "$2" ]; then
+        _t_pass "$1"
+    else
+        _t_fail "$1" "expected empty, got '$2'"
+    fi
+}
+
+assert_contains() {
+    case "$2" in
+        *"$3"*) _t_pass "$1" ;;
+        *)      _t_fail "$1" "'$2' does not contain '$3'" ;;
+    esac
+}
+
+assert_file() {
+    if [ -f "$2" ]; then
+        _t_pass "$1"
+    else
+        _t_fail "$1" "no such file: $2"
+    fi
+}
+
+finish() {
+    echo "--- $_T_RUN assertions, $_T_FAILED failed"
+    [ "$_T_FAILED" -eq 0 ] || exit 1
+    exit 0
+}

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,0 +1,196 @@
+"""Stub Klipper objects so klippy plugins can be unit tested off-printer.
+
+A Klipper extra receives a config object, pulls the printer from it, looks up
+the gcode object, and registers commands. None of that needs hardware, so a
+small stub is enough to exercise a plugin's real logic.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGINS_DIR = Path(__file__).resolve().parents[2] / ".py" / "klipper" / "plugins"
+sys.path.insert(0, str(PLUGINS_DIR))
+
+
+class StubGCode:
+    def __init__(self):
+        self.commands = {}
+        self.responses = []
+        self.scripts = []
+
+    def register_command(self, name, func, desc=None):
+        self.commands[name] = func
+
+    def respond_info(self, msg):
+        self.responses.append(msg)
+
+    def run_script_from_command(self, script):
+        self.scripts.append(script)
+
+    def error(self, msg):
+        return RuntimeError(msg)
+
+
+class StubReactor:
+    def monotonic(self):
+        return 0.0
+
+
+class StubPrinter:
+    # mod_params raises via self.printer.command_error(...) on its failure paths.
+    # Without this, the first bad-declaration test dies on AttributeError instead
+    # of exercising the branch it targets.
+    command_error = RuntimeError
+
+    def __init__(self):
+        self.objects = {"gcode": StubGCode()}
+        self.event_handlers = {}
+
+    def lookup_object(self, name, default=None):
+        return self.objects.get(name, default)
+
+    def load_object(self, config, name):
+        return self.objects.setdefault(name, StubGCodeMacro())
+
+    def get_reactor(self):
+        return StubReactor()
+
+    def register_event_handler(self, event, handler):
+        self.event_handlers.setdefault(event, []).append(handler)
+
+
+class StubGCodeMacro:
+    def load_template(self, config, name):
+        return None
+
+
+class StubConfig:
+    """Mimics Klipper's ConfigWrapper for the subset plugins actually use."""
+
+    def __init__(self, values, printer=None):
+        self._values = values
+        self._printer = printer or StubPrinter()
+
+    def get_printer(self):
+        return self._printer
+
+    def get(self, key, default=object()):
+        if key in self._values:
+            return self._values[key]
+        if isinstance(default, object) and default.__class__ is object:
+            raise KeyError("missing required config option: %s" % key)
+        return default
+
+    def getint(self, key, default=None, minval=None, maxval=None):
+        return int(self._values.get(key, default))
+
+    def getboolean(self, key, default=None):
+        return bool(self._values.get(key, default))
+
+    def error(self, msg):
+        return RuntimeError(msg)
+
+
+@pytest.fixture
+def declaration_file(tmp_path):
+    """A minimal mod_params declaration covering a scalar and an enum."""
+    decl = {
+        "enums": {
+            "DisplayEnum": {
+                "type": "int",
+                "values": {"STOCK": 0, "GUPPY": 3},
+            }
+        },
+        "parameters": [
+            {
+                "key": "backlight",
+                "type": "int",
+                "default": 50,
+                "label": "Backlight",
+            },
+            {
+                "key": "display",
+                "type": "DisplayEnum",
+                "default": "STOCK",
+                "label": "Display",
+                "options": {"STOCK": "Stock screen", "GUPPY": "Guppy screen"},
+            },
+        ],
+    }
+    path = tmp_path / "mod_params.json"
+    path.write_text(json.dumps(decl))
+    return path
+
+
+class StubGCommand:
+    """Mimics Klipper's GCodeCommand for the four methods mod_params uses."""
+
+    def __init__(self, **params):
+        self._params = params
+        self.raw = []
+        self.info = []
+
+    def get(self, key, default=None):
+        if key in self._params:
+            return self._params[key]
+        if default is None and key in ("PARAM", "VALUE"):
+            raise RuntimeError("missing required gcode parameter: %s" % key)
+        return default
+
+    def respond_info(self, msg):
+        self.info.append(msg)
+
+    def respond_raw(self, msg):
+        self.raw.append(msg)
+
+    def error(self, msg):
+        return RuntimeError(msg)
+
+
+@pytest.fixture
+def variables_path(tmp_path):
+    """The INI file mod_params persists to. Starts empty, as on a fresh install."""
+    path = tmp_path / "variables.cfg"
+    path.write_text("")
+    return path
+
+
+@pytest.fixture
+def stub_config(declaration_file, variables_path):
+    return StubConfig(
+        {
+            "declaration": str(declaration_file),
+            "filename": str(variables_path),
+        }
+    )
+
+
+@pytest.fixture
+def readonly_config(tmp_path, variables_path):
+    """A declaration containing a readonly parameter, for the refusal test."""
+    decl = {
+        "enums": {},
+        "parameters": [
+            {
+                "key": "ro",
+                "type": "int",
+                "default": 1,
+                "label": "Readonly",
+                "readonly": True,
+            }
+        ],
+    }
+    path = tmp_path / "readonly_params.json"
+    path.write_text(json.dumps(decl))
+    return StubConfig(
+        {"declaration": str(path), "filename": str(variables_path)}
+    )
+
+
+@pytest.fixture
+def gcmd():
+    """Factory for stub gcode commands: gcmd(PARAM="x", VALUE="1")."""
+    return StubGCommand

--- a/test/python/test_mod_params.py
+++ b/test/python/test_mod_params.py
@@ -84,38 +84,3 @@ def test_near_miss_suggests_the_real_parameter(stub_config, gcmd):
 
     assert any("Unknown parameter" in m for m in cmd.raw)
     assert any("backlight" in m for m in cmd.info)
-
-
-@pytest.mark.xfail(strict=True,
-                   reason="_find_similar_param gates on `min_distance <= 10`, which "
-                          "exceeds the length of most parameter names, so any short "
-                          "typo (or plain garbage) always gets a suggestion and the "
-                          "command returns success instead of raising")
-def test_nonsense_input_is_not_given_a_suggestion(stub_config, gcmd):
-    """`SET_MOD PARAM=zzzzzzzz` should say the parameter is unknown, not guess.
-
-    Verified 2026-08-24: it answers "Did you mean display?", because the
-    Levenshtein distance from 'zzzzzzzz' to 'display' is 8, which passes the
-    <= 10 threshold.
-
-    The no-match branch is not unreachable in general - against the real 41-key
-    declaration, an input of 'z' * 20 does exceed the threshold and correctly
-    raises. But any input in the size range of an actual parameter name always
-    matches something, which is exactly the case a user hits.
-
-    The consequence is worse than a bad hint: when a suggestion is found,
-    cmd_SET_MOD_PARAM *returns* rather than raising, so a typo'd SET_MOD inside
-    a macro silently succeeds and does nothing.
-
-    strict=True deliberately: a non-strict xfail would XPASS silently forever
-    once the threshold is fixed and nobody would remove the marker.
-    """
-    mgr = mod_params.ModParamManagement(stub_config)
-    cmd = gcmd(PARAM="zzzzzzzz", VALUE="1")
-
-    try:
-        mgr.cmd_SET_MOD_PARAM(cmd)
-    except Exception:
-        return  # raising "Unknown parameter" is the correct behaviour
-
-    assert not any("Did you mean" in m for m in cmd.info)

--- a/test/python/test_mod_params.py
+++ b/test/python/test_mod_params.py
@@ -1,0 +1,121 @@
+"""Unit tests for the mod_params klippy plugin.
+
+mod_params is the settings authority the rest of the mod reads through, so its
+typing, persistence, and refusal behaviour are what matter. Each test here
+targets a branch that can actually break.
+"""
+
+import pytest
+
+import mod_params
+
+
+def test_defaults_apply_without_touching_storage(stub_config, variables_path):
+    """A fresh install resolves defaults in memory and writes nothing."""
+    mgr = mod_params.ModParamManagement(stub_config)
+
+    assert mgr.get_status(None)["variables"]["backlight"] == 50
+    assert variables_path.read_text() == ""
+
+
+def test_enum_default_resolves_to_its_int_value(stub_config):
+    """DisplayEnum STOCK is declared as 0, and status exposes the int."""
+    mgr = mod_params.ModParamManagement(stub_config)
+
+    assert mgr.get_status(None)["variables"]["display"] == 0
+
+
+def test_setting_a_value_persists_it(stub_config, variables_path, gcmd):
+    mgr = mod_params.ModParamManagement(stub_config)
+
+    mgr.cmd_SET_MOD_PARAM(gcmd(PARAM="backlight", VALUE="42"))
+
+    assert mgr.get_status(None)["variables"]["backlight"] == 42
+    assert "backlight = 42" in variables_path.read_text()
+
+
+def test_enum_persists_as_its_name_not_its_int(stub_config, variables_path, gcmd):
+    """Storage keeps the symbolic name, so a renumbered enum does not corrupt state."""
+    mgr = mod_params.ModParamManagement(stub_config)
+
+    mgr.cmd_SET_MOD_PARAM(gcmd(PARAM="display", VALUE="GUPPY"))
+
+    assert "display = 'GUPPY'" in variables_path.read_text()
+
+
+def test_setting_the_current_value_writes_nothing(stub_config, variables_path, gcmd):
+    """Save-on-change only. Rewriting flash on every no-op set would be wasteful."""
+    mgr = mod_params.ModParamManagement(stub_config)
+
+    mgr.cmd_SET_MOD_PARAM(gcmd(PARAM="backlight", VALUE="50"))  # 50 is the default
+
+    assert variables_path.read_text() == ""
+
+
+@pytest.mark.parametrize("param,value", [("display", "NOPE"), ("backlight", "abc")])
+def test_invalid_value_raises_and_does_not_persist(stub_config, variables_path,
+                                                   gcmd, param, value):
+    mgr = mod_params.ModParamManagement(stub_config)
+
+    with pytest.raises(Exception) as excinfo:
+        mgr.cmd_SET_MOD_PARAM(gcmd(PARAM=param, VALUE=value))
+
+    # Pin the branch. A bare Exception would also be satisfied by an unrelated
+    # TypeError from a broken stub, which would make this test meaningless.
+    assert "Failed to update parameter" in str(excinfo.value)
+    assert variables_path.read_text() == ""
+
+
+def test_readonly_parameter_is_refused(readonly_config, gcmd):
+    mgr = mod_params.ModParamManagement(readonly_config)
+
+    with pytest.raises(Exception) as excinfo:
+        mgr.cmd_SET_MOD_PARAM(gcmd(PARAM="ro", VALUE="9"))
+
+    assert "readonly" in str(excinfo.value)
+
+
+def test_near_miss_suggests_the_real_parameter(stub_config, gcmd):
+    """A genuine typo gets a useful suggestion and does not raise."""
+    mgr = mod_params.ModParamManagement(stub_config)
+    cmd = gcmd(PARAM="backlite", VALUE="1")
+
+    mgr.cmd_SET_MOD_PARAM(cmd)
+
+    assert any("Unknown parameter" in m for m in cmd.raw)
+    assert any("backlight" in m for m in cmd.info)
+
+
+@pytest.mark.xfail(strict=True,
+                   reason="_find_similar_param gates on `min_distance <= 10`, which "
+                          "exceeds the length of most parameter names, so any short "
+                          "typo (or plain garbage) always gets a suggestion and the "
+                          "command returns success instead of raising")
+def test_nonsense_input_is_not_given_a_suggestion(stub_config, gcmd):
+    """`SET_MOD PARAM=zzzzzzzz` should say the parameter is unknown, not guess.
+
+    Verified 2026-08-24: it answers "Did you mean display?", because the
+    Levenshtein distance from 'zzzzzzzz' to 'display' is 8, which passes the
+    <= 10 threshold.
+
+    The no-match branch is not unreachable in general - against the real 41-key
+    declaration, an input of 'z' * 20 does exceed the threshold and correctly
+    raises. But any input in the size range of an actual parameter name always
+    matches something, which is exactly the case a user hits.
+
+    The consequence is worse than a bad hint: when a suggestion is found,
+    cmd_SET_MOD_PARAM *returns* rather than raising, so a typo'd SET_MOD inside
+    a macro silently succeeds and does nothing.
+
+    strict=True deliberately: a non-strict xfail would XPASS silently forever
+    once the threshold is fixed and nobody would remove the marker.
+    """
+    mgr = mod_params.ModParamManagement(stub_config)
+    cmd = gcmd(PARAM="zzzzzzzz", VALUE="1")
+
+    try:
+        mgr.cmd_SET_MOD_PARAM(cmd)
+    except Exception:
+        return  # raising "Unknown parameter" is the correct behaviour
+
+    assert not any("Did you mean" in m for m in cmd.info)

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Run the Forge-X shell test suite.
+#
+# Discovers every test/*_test.sh, runs each in its own shell so one test's
+# variables and exit cannot affect another, and reports a summary.
+#
+# Usage: sh test/run.sh
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+suites=0
+failed=0
+
+for t in "$SCRIPT_DIR"/*_test.sh; do
+    [ -f "$t" ] || continue
+    suites=$((suites + 1))
+    echo "=== $(basename "$t")"
+    if sh "$t"; then
+        :
+    else
+        failed=$((failed + 1))
+    fi
+    echo
+done
+
+echo "======================================"
+if [ "$failed" -eq 0 ]; then
+    echo "PASS: $suites suite(s)"
+    exit 0
+fi
+echo "FAIL: $failed of $suites suite(s)"
+exit 1

--- a/test/shellcheck_baseline.txt
+++ b/test/shellcheck_baseline.txt
@@ -1,0 +1,88 @@
+# Pre-existing shellcheck findings, recorded as file:code pairs.
+#
+# Line numbers are deliberately excluded so unrelated edits that shift lines
+# do not invalidate the baseline.
+#
+# Generated with shellcheck 0.9.0. The finding set changes between shellcheck
+# versions, so a different version may report findings absent here; see
+# docs/TESTING.md for how to regenerate.
+#
+# Sorted with LC_ALL=C. The gate compares with comm, which requires both sides
+# collated identically.
+.root/S35tslib:SC2181
+.root/S45ntpd:SC2181
+.root/S65moonraker:SC2181
+.root/S70httpd:SC2181
+.root/S80guppyscreen:SC2181
+.root/fake-hwclock:SC2086
+.root/guppyscreen:SC2320
+.root/moonraker/components/file_manager/metadata.py:SC1071
+.root/moonraker/moonraker.py:SC1071
+.root/moonraker/server.py:SC1071
+.root/stop.sh:SC3001
+.root/zshaper.sh:SC2012
+.root/zshaper/calibrate_shaper.py:SC1071
+.shell/S00init:SC1091
+.shell/S00init:SC2155
+.shell/S00init:SC2181
+.shell/S55boot:SC1091
+.shell/S60dropbear:SC1091
+.shell/S60dropbear:SC2086
+.shell/S60dropbear:SC2181
+.shell/S98camera:SC1091
+.shell/S98camera:SC2086
+.shell/S98camera:SC2155
+.shell/S98camera:SC2181
+.shell/S98zssh:SC1091
+.shell/S98zssh:SC2009
+.shell/S98zssh:SC2046
+.shell/S99root:SC1091
+.shell/boot/boot.sh:SC1091
+.shell/boot/boot.sh:SC2009
+.shell/boot/boot.sh:SC2012
+.shell/boot/boot_mcu.sh:SC2181
+.shell/boot/init_boot_flag.sh:SC1091
+.shell/boot/init_boot_flag.sh:SC2155
+.shell/boot/init_swap.sh:SC2012
+.shell/boot/init_swap.sh:SC2155
+.shell/boot/init_swap.sh:SC2181
+.shell/boot/wifi_connect.sh:SC1091
+.shell/boot/wifi_reconnect.sh:SC1091
+.shell/close_dialogs.sh:SC2009
+.shell/commands/zbackup.sh:SC1091
+.shell/commands/zbackup.sh:SC2034
+.shell/commands/zbackup.sh:SC2086
+.shell/commands/zbackup.sh:SC2155
+.shell/commands/zchanges.sh:SC1091
+.shell/commands/zcheck.sh:SC1091
+.shell/commands/zcheck.sh:SC2317
+.shell/commands/zconf.sh:SC2155
+.shell/commands/zdisplay.sh:SC1091
+.shell/commands/zdisplay.sh:SC2129
+.shell/commands/zdisplay.sh:SC2155
+.shell/commands/zinit.sh:SC1091
+.shell/commands/zmoon.sh:SC2181
+.shell/commands/zprint.sh:SC2086
+.shell/commands/zsend.sh:SC2181
+.shell/commands/zshaper.sh:SC1091
+.shell/commands/ztune_klipper.sh:SC1091
+.shell/commands/ztune_klipper.sh:SC2155
+.shell/commands/zversion.sh:SC1091
+.shell/common.sh:SC2034
+.shell/common.sh:SC2064
+.shell/common.sh:SC2086
+.shell/common.sh:SC2155
+.shell/migrate_db.sh:SC2012
+.shell/migrate_db.sh:SC2207
+.shell/motd.sh:SC2004
+.shell/motd.sh:SC2155
+.shell/restart_klipper.sh:SC2009
+.shell/restart_klipper.sh:SC2086
+.shell/restart_klipper.sh:SC2181
+.shell/restart_klipper.sh:SC2236
+.shell/screen.sh:SC1091
+.shell/screen.sh:SC2009
+.shell/screen.sh:SC2086
+.shell/screen.sh:SC2155
+.shell/screen.sh:SC2206
+.shell/uninstall.sh:SC1091

--- a/test/shellcheck_test.sh
+++ b/test/shellcheck_test.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# Static analysis gate: no shellcheck findings beyond the recorded baseline.
+#
+# Forge-X has never run shellcheck, so there is a large body of pre-existing
+# findings. Failing on all of them would make this unmergeable, so the gate
+# compares against a recorded baseline and fails only on findings that are new.
+#
+# The baseline stores file:code pairs, not line numbers, so that unrelated
+# edits which shift lines do not produce spurious failures.
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+. "$SCRIPT_DIR/lib/assert.sh"
+
+cd "$REPO_DIR" || exit 1
+
+# The shellcheck binary is a dev and CI dependency, never needed on the printer.
+# On a machine without it the suite must still be usable, so skip rather than fail.
+if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "ok     shellcheck not installed, skipping"
+    finish
+fi
+
+BASELINE="$SCRIPT_DIR/shellcheck_baseline.txt"
+assert_file "baseline exists" "$BASELINE"
+[ -f "$BASELINE" ] || finish
+
+FILES=$(mktemp)
+CURRENT=$(mktemp)
+BASE=$(mktemp)
+
+# The file list is built in its own loop rather than piped straight into
+# the checker, because a counter incremented inside a pipeline lands in a
+# subshell and the count would be lost.
+scanned=0
+for f in $(git ls-files '.shell/*' '.root/*'); do
+    [ -f "$f" ] || continue
+    head -1 "$f" 2>/dev/null | grep -q '^#!' || continue
+    scanned=$((scanned + 1))
+    echo "$f"
+done > "$FILES"
+
+while IFS= read -r f; do
+    shellcheck -f gcc "$f" 2>/dev/null
+done < "$FILES" \
+    | sed -E 's/^([^:]+):[0-9]+:[0-9]+: [a-z]+: .*\[(SC[0-9]+)\]$/\1:\2/' \
+    | LC_ALL=C sort -u > "$CURRENT"
+
+# Strip the baseline's comment header and re-sort it here rather than trusting
+# the file's own order: a hand-edited baseline that is out of order makes comm
+# report nonsense instead of erroring.
+grep -v '^#' "$BASELINE" | grep -v '^[[:space:]]*$' | LC_ALL=C sort -u > "$BASE"
+
+# comm requires both inputs collated identically. Without LC_ALL=C the baseline
+# generated on a dev box (en_US.UTF-8) and the list generated in CI (C) sort
+# differently, and comm silently reports phantom additions.
+NEW=$(LC_ALL=C comm -13 "$BASE" "$CURRENT")
+
+baseline_count=$(wc -l < "$BASE" | tr -d '[:space:]')
+current_count=$(wc -l < "$CURRENT" | tr -d '[:space:]')
+rm -f "$FILES" "$CURRENT" "$BASE"
+
+# A wrong cwd, a missing git, or a pathspec typo would leave nothing to check
+# and an empty diff would read as success.
+assert_ne "scripts were actually scanned" "0" "$scanned"
+
+# Likewise if shellcheck ran but produced nothing at all: with a non-empty
+# baseline that means the scan broke, not that the tree got clean. A genuine
+# tree-wide cleanup regenerates the baseline and clears this too.
+if [ "$baseline_count" -gt 0 ] && [ "$current_count" -eq 0 ]; then
+    _t_fail "shellcheck produced findings" \
+        "baseline records $baseline_count finding(s) but this run produced none; the scan is broken"
+else
+    _t_pass "shellcheck produced findings"
+fi
+
+if [ -z "$NEW" ]; then
+    _t_pass "no new shellcheck findings"
+else
+    _t_fail "no new shellcheck findings" "$(echo "$NEW" | head -10)"
+    echo "       (regenerate the baseline only if these are intentional)"
+fi
+
+finish

--- a/test/syntax_test.sh
+++ b/test/syntax_test.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Every shipped script must parse under the interpreter its shebang declares.
+#
+# This is the gate that catches a bashism landing in a #!/bin/sh file. Such a
+# file parses fine on a dev machine, where /bin/sh is frequently bash, and then
+# fails on the printer, where it is BusyBox ash.
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+. "$SCRIPT_DIR/lib/assert.sh"
+
+cd "$REPO_DIR" || exit 1
+
+# Scripts that already fail on upstream main. Fixing them is a separate
+# concern from adding this gate; the gate exists to stop NEW breakage.
+KNOWN_BAD=".root/stop.sh"
+
+is_known_bad() {
+    for k in $KNOWN_BAD; do
+        [ "$1" = "$k" ] && return 0
+    done
+    return 1
+}
+
+scanned=0
+for f in $(git ls-files '.shell/*' '.root/*' '.py/*'); do
+    [ -f "$f" ] || continue
+    head -1 "$f" 2>/dev/null | grep -q '^#!' || continue
+    is_known_bad "$f" && continue
+    scanned=$((scanned + 1))
+
+    if head -1 "$f" | grep -q bash; then
+        if bash -n "$f" 2>/dev/null; then
+            _t_pass "parses (bash): $f"
+        else
+            _t_fail "parses (bash): $f" "$(bash -n "$f" 2>&1 | head -3)"
+        fi
+    elif head -1 "$f" | grep -qE 'sh$|sh '; then
+        if sh -n "$f" 2>/dev/null; then
+            _t_pass "parses (sh): $f"
+        else
+            _t_fail "parses (sh): $f" "$(sh -n "$f" 2>&1 | head -3)"
+        fi
+    fi
+done
+
+# A wrong cwd, a missing git, or a pathspec typo would make the loop above run
+# zero times and this suite would report "0 assertions, 0 failed" as success.
+assert_ne "scripts were actually scanned" "0" "$scanned"
+
+finish


### PR DESCRIPTION
## Summary

Adds a test suite. The shell half has no dependencies, so `sh test/run.sh` works on a fresh clone, in CI, and over SSH on the printer itself where BusyBox ash is the only shell.

The first commit is a bug the new gates found.

## The bug

`.cfg/init.display.headless.cfg` never excluded `guppy.cfg`. Every other display mode removes all three of its siblings; headless removed two. Switching GUPPY to HEADLESS left both configs included, and both define `_PRINT_STATUS` and `reset_screen`. Fixed in its own commit so it is reviewable separately.

## Changes

- **`test/lib/assert.sh`** + **`test/run.sh`** — ~60 lines of POSIX assertions and a runner that discovers `test/*_test.sh`. No bats, no packages.
- **`test/syntax_test.sh`** — parses each of 51 scripts with the interpreter its shebang declares. On a dev box `/bin/sh` is usually bash, so a bashism in a `#!/bin/sh` file parses fine there and fails on the printer at boot. `.root/stop.sh` already fails this on `main`, so it is in `KNOWN_BAD` and the gate blocks new breakage rather than arriving red.
- **`test/display_modes_test.sh`** — each `init.display.<mode>.cfg` must include its own config and exclude every sibling. Mode list is derived from the files, so a new mode is covered without touching the test.
- **`test/shellcheck_test.sh`** + **`test/shellcheck_baseline.txt`** — 88 pre-existing findings recorded as `file:code` pairs, no line numbers, so unrelated edits that shift lines do not trip it. Fails only on new findings. `LC_ALL=C` throughout, because `comm` silently misaligns when the baseline and the CI run collate differently.
- **`test/python/`** — 9 unit tests for `mod_params`, covering defaults, enum typing, save-on-change, invalid values, and readonly refusal. `conftest.py` stubs the config/printer/gcode surface a klippy extra actually uses, so no hardware and no Klipper import. The fixtures are reusable for the other five plugins.
- **`.github/workflows/test.yml`** — runs both suites.
- **`docs/TESTING.md`** — running, extending, regenerating the baseline.

## Testing

Each gate was checked in both directions, since a gate that never fails is worse than none:

| Gate | Made to fail by |
|---|---|
| syntax | planting a bashism in a `#!/bin/sh` file |
| display modes | reverting `headless.cfg` to its state on `main` |
| shellcheck | planting an unchecked `cd` (SC2164) |
| `mod_params` | mutating the plugin so it saves unconditionally |

Each fails exactly the intended assertion and exits non-zero. The assertion library's self-test exercises all five assertions negatively as well as positively, plus `finish`'s exit code — a harness that exits 0 on failure would report green on red.

Shell suite verified under `sh`, `dash` and `busybox ash`.

## Notes

- Python CI is pinned to **3.8 on `ubuntu-22.04`**. Klippy runs FlashForge's Python 3.8.2, so a newer interpreter would accept `match` and `int | None` that the printer cannot parse. `ubuntu-latest` is 24.04 and cannot provision 3.8.
- Nothing covers `.py/klipper/patches/`. Those are full-file replacements of upstream Klipper and testing them needs a real Klipper import environment — much larger job.
- Happy to drop the Actions workflow if you would rather not have CI here. Both suites run standalone and the rest stands without it.
