### PR TITLE
Debounce bed collision M112 shutdown to avoid false positives from pr…

### DIFF
--- a/.py/klipper/patches/extras/temperature_sensor.py
+++ b/.py/klipper/patches/extras/temperature_sensor.py
@@ -2,6 +2,13 @@
 #
 # Changes:
 # - Added gcode code to execute if value out of range
+# - Added optional min_exceed_count debounce: require N consecutive
+#   over-threshold samples before running exceed_gcode. Without this a
+#   single noisy/transient reading (e.g. a print blob briefly loading the
+#   AD5M's bed load cell) is enough to trip the immediate M112 shutdown
+#   path below, with no way to tell that apart from a genuine, sustained
+#   nozzle collision. Defaults to 1 (fires on the first sample, identical
+#   to prior behavior) so existing configs are unaffected.
 #
 # Copyright (C) 2025, Alexander K <https://github.com/drA1ex>
 #
@@ -32,6 +39,7 @@ class PrinterSensorGeneric:
         self.gcode_throttle = config.getfloat("throttle", 1., minval=0)
         self.gcode_reschedule = config.getboolean("reschedule", False)
         self.gcode_reschedule_cooldown = config.getfloat("reschedule_cooldown", 1., minval=0)
+        self.min_exceed_count = config.getint("min_exceed_count", 1, minval=1)
         gcode_macro = self.printer.load_object(config, "gcode_macro")
         self.exceed_gcode_present = config.get("exceed_gcode", None) is not None
         if self.exceed_gcode_present:
@@ -46,6 +54,7 @@ class PrinterSensorGeneric:
         self._throttle_max_value = float("-inf")
         self._callback_scheduled = False
         self._last_exceed = 0
+        self._consecutive_exceed = 0
 
     m112_r = re.compile(r"^(?:[nN][0-9]+)?\s*[mM]112(?:\s|$)", re.MULTILINE)
 
@@ -55,8 +64,13 @@ class PrinterSensorGeneric:
             self.measured_min = min(self.measured_min, temp)
             self.measured_max = max(self.measured_max, temp)
 
-            if self.exceed_gcode_present and (temp >= self.trigger_value):
-                self._handle_exceed(temp)
+            if self.exceed_gcode_present:
+                if temp >= self.trigger_value:
+                    self._consecutive_exceed += 1
+                    if self._consecutive_exceed >= self.min_exceed_count:
+                        self._handle_exceed(temp)
+                else:
+                    self._consecutive_exceed = 0
 
     def _template(self, value):
         context = self.exceed_template.create_template_context()

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -289,7 +289,7 @@ The system has two stages:
 To customize the warning limit, you can modify the `user.cfg` file by adding the following:
 
 ```cfg
-[temperature_sensor weight_value]
+[temperature_sensor weightValue]
 trigger_value: 700
 ```
 
@@ -297,6 +297,19 @@ Be careful: setting values greater than weight_check_max will increase the actua
 
 For more information, refer to the [Printing Page](https://github.com/DrA1ex/ff5m/blob/main/docs/PRINTING.md) and the [Configuration Page](https://github.com/DrA1ex/ff5m/blob/main/docs/CONFIGURATION.md).  
 
+
+#### Why does this trigger from a small print blob, and can it tell the difference from a real crash?
+
+The critical (error) stage runs `M112` — an immediate MCU shutdown — the moment a single load cell reading crosses `weight_check_max`, with no debounce. A genuine nozzle-into-bed/model collision keeps loading the sensor on every following reading, but so, briefly, can a blob, warped edge, or oozing corner that the nozzle merely brushes past. The sensor can't distinguish the two from one sample alone, so a harmless print artifact could trip the same hard, unrecoverable stop as a real crash.
+
+Forge-X's `[temperature_sensor weightValue]` now exposes `min_exceed_count`, which requires that many *consecutive* over-threshold readings before `exceed_gcode` (and therefore `M112`) runs at all — `macros/base.cfg` sets it to `3` by default. A real collision still trips within a few samples; an isolated spike from a print artifact does not. Raise it further in `user.cfg` if you still see false positives on a particular print style, or set it back to `1` to restore the old single-sample behavior:
+
+```cfg
+[temperature_sensor weightValue]
+min_exceed_count: 5
+```
+
+This only changes *when* the check fires, not what it protects against — it still stops the MCU immediately once triggered, it just insists the pressure is sustained first.
 
 #### Possible causes of this error include:  
 - **Weight cell calibration issues**: If you manually leveled the bed, it might require recalibration.  

--- a/macros/base.cfg
+++ b/macros/base.cfg
@@ -45,6 +45,14 @@ screw_thread: CW-M4
 trigger_value: 1000
 throttle: 10
 reschedule: False
+# Require the load cell to read above trigger_value on 3 consecutive samples
+# before exceed_gcode runs at all. A genuine nozzle-into-bed/model collision
+# keeps loading the sensor on every following sample; a print artifact
+# (blob, warped edge, oozing corner) that briefly nudges the sensor as the
+# head passes over it usually only shows up for a sample or two. Without
+# this, a single noisy/transient reading was enough to trip the immediate
+# M112 shutdown below with no way to resume - see docs/FAQ.md.
+min_exceed_count: 3
 exceed_gcode:
     {% set weight_check = printer.mod_params.variables.weight_check %}
     {% set weight_check_max = printer.mod_params.variables.weight_check_max %}


### PR DESCRIPTION

<img width="4000" height="3000" alt="20260828_221610" src="https://github.com/user-attachments/assets/518c25a9-0c2b-4ad3-9c42-e1a71ffe0321" />
<img width="4000" height="3000" alt="20260828_221557" src="https://github.com/user-attachments/assets/cd60a7f2-483a-4008-8806-9fbbbb733f7f" />
Human comments: I made these changes to my fork to prevent the printer hanging up unnecessarily if there is some tiny bump in the print, but still protect against crashing the nozzle. The main issue is bigger: for some reason I couldn't resume a print after this weight sensor trips. That is a separate investigation.

Claude wrote up this description:
The weightValue exceed_gcode ran M112 (immediate MCU shutdown, unrecoverable without a firmware restart) on a single load-cell sample crossing weight_check_max, with no debounce. A real nozzle collision keeps loading the sensor on every following sample, but a brief blob/warped edge/oozing corner the nozzle merely brushes past could trigger the identical hard stop from one noisy reading.

a single noisy reading — the head dragging over a zit, or a big model's own accumulating weight, or if the extrusion rate is a touch too high, or if the model has flexible parts that might momentarily bump against the nozzle because they are flexing a little bit, or a human bumping the bed during a filament change numerous ways to trigger an unrecoverable firmware shutdown. And idle_timeout stays "Printing" for the whole idle-timeout window while paused, so bumping a blob during a pause does it too.

Add an opt-in min_exceed_count option to the generic temperature_sensor patch (default 1, preserving prior single-sample behavior for any other consumer) requiring N consecutive over-threshold readings before exceed_gcode fires. Set it to 3 for weightValue so genuine, sustained pressure still trips quickly while isolated spikes don't.

Also fixes the FAQ's user.cfg override example, which named the section weight_value instead of the actual weightValue - a mismatch that silently created an unrelated sensor instead of overriding the real one.